### PR TITLE
feat: use alpine:3.22 as base image

### DIFF
--- a/images/Dockerfile-bash-jq
+++ b/images/Dockerfile-bash-jq
@@ -1,7 +1,9 @@
-FROM alpine:3.22 AS builder
+FROM alpine:3.22
 
-RUN apk add --no-cache jq
+RUN apk add --no-cache bash curl jq ca-certificates \
+    && rm -rf /var/cache/apk/* \
+    && rm -f /sbin/apk /bin/apk /usr/bin/apk
 
-FROM chainguard/bash:latest
+ENV SHELL=/bin/bash
 
-COPY --from=builder /usr/bin/jq /usr/bin/jq
+CMD ["/bin/bash"]


### PR DESCRIPTION
- Alpine based image 50% compacter than chainguard/bash image.
- Installs the only required dependencies.

```bash
$ docker images
REPOSITORY                               TAG                                                              IMAGE ID       CREATED          SIZE
alpine-secure-dirty                      v2                                                               350e96e8f015   20 minutes ago   16.9MB
chainguard-bash-jq-dirty                 latest                                                           973071fb81d0   2 days ago       33.6MB
```