### PR TITLE
include dig into image

### DIFF
--- a/images/Dockerfile-bash-curl-jq
+++ b/images/Dockerfile-bash-curl-jq
@@ -1,6 +1,6 @@
 FROM alpine:3.23.3
 
-RUN apk add --no-cache bash curl jq ca-certificates \
+RUN apk add --no-cache bash curl jq ca-certificates bind-tools \
     && rm -rf /var/cache/apk/* \
     && rm -f /sbin/apk /bin/apk /usr/bin/apk
 


### PR DESCRIPTION
bind-tools contains dig: https://pkgs.alpinelinux.org/contents?name=bind-tools&repo=main&branch=edge&arch=x86
...which we need in this image to resolve one of the monitoring endpoints into a list of IPs